### PR TITLE
test for dev version sync false fails when dev version produces no gi…

### DIFF
--- a/.github/workflows/pr-basic-tests.yml
+++ b/.github/workflows/pr-basic-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  basic-tests:
     runs-on: ${{ matrix.os }}
     env:
       term: xterm

--- a/.github/workflows/pr-dev-version-sync-tests.yml
+++ b/.github/workflows/pr-dev-version-sync-tests.yml
@@ -1,4 +1,4 @@
-name: Basic Tests
+name: Dev Version Tests
 
 on:
   pull_request:

--- a/.github/workflows/pr-dev-version-sync-tests.yml
+++ b/.github/workflows/pr-dev-version-sync-tests.yml
@@ -1,0 +1,37 @@
+name: Basic Tests
+
+on:
+  pull_request:
+
+jobs:
+  dev-version-tests:
+    runs-on: ${{ matrix.os }}
+    env:
+      term: xterm
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+        node-version:
+          - '20'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install node ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - name: Install deps and prep
+        run: |
+          npm clean-install
+          npm run prepare
+      - name: Export pkg.json version
+        run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+      - name: Prepare release
+        uses: ./
+        with:
+          version: v${{ env.VERSION }}
+          sync: false

--- a/.github/workflows/pr-options-tests.yml
+++ b/.github/workflows/pr-options-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  options-test:
     runs-on: ${{ matrix.os }}
     env:
       term: xterm

--- a/.github/workflows/pr-options-tests.yml
+++ b/.github/workflows/pr-options-tests.yml
@@ -114,13 +114,3 @@ jobs:
           fi
         shell: bash
 
-      - name: "TEST: should set git message correctly"
-        if: always()
-        run: |
-          if git --no-pager log -1 | grep "riker5.0.0"; then
-            echo "::notice title=TEST PASSED::Git message set correctly"
-          else
-            echo "::error title=TEST FAILED!::Git message not set correctly"
-            exit 5
-          fi
-        shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed issue where `version: dev` would fail when it produces no `git` changes
+
 ## v3.3.1 - [May 8, 2024](https://github.com/lando/prepare-release-action/releases/tag/v3.3.1)
 
 * Fixed issue with `update-files-header` newline spacing

--- a/prepare-release.js
+++ b/prepare-release.js
@@ -161,7 +161,7 @@ const main = async () => {
     }
 
     // bump version AND commit everything changed
-    await exec.exec(`${binDir}/bump`, [inputs.version, '--commit', inputs.syncMessage, '--all']);
+    await exec.exec(`${binDir}/bump`, inputs.sync ? [inputs.version, '--commit', inputs.syncMessage, '--all'] : [inputs.version]);
 
     // get helpful stuff, for some reasons windows interprets the format wrapping quptes literally?
     const currentCommit = getStdOut('git --no-pager log --pretty=format:%h -n 1');


### PR DESCRIPTION
…t changes

### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)
- [ ] I've updated this PR with the latest code from `main`
- [ ] I've done a cursory QA pass of my code locally
- [ ] I've ensured all automated status check and tests pass
- [ ] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [ ] I've written a unit or functional test for my code
- [ ] I've updated relevant documentation it my code changes it
- [ ] I've updated this repo's README if my code changes it
- [ ] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
