### PR TITLE
Fix error when package has no dependencies

### DIFF
--- a/.github/workflows/label-add-to-project.yml
+++ b/.github/workflows/label-add-to-project.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         flag:
           - flag
 

--- a/.github/workflows/pr-basic-tests.yml
+++ b/.github/workflows/pr-basic-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         version:
           - v0.0.1-riker.1
           - 1.0.0-beta.1

--- a/.github/workflows/pr-dev-version-sync-tests.yml
+++ b/.github/workflows/pr-dev-version-sync-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         node-version:
           - '20'
 

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         node-version:
           - '20'
 

--- a/.github/workflows/pr-options-tests.yml
+++ b/.github/workflows/pr-options-tests.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         os:
           - windows-2022
-          - ubuntu-22.04
-          - macos-12
+          - ubuntu-24.04
+          - macos-14
         node-version:
           - '20'
 

--- a/.github/workflows/pr-sync-tests.yml
+++ b/.github/workflows/pr-sync-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         node-version:
           - '20'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         node-version:
           - '20'
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed issue where `bundle-dependencies` would fail when no dependencies are found in `package.json`
+
 ## v3.3.2 - [May 25, 2024](https://github.com/lando/prepare-release-action/releases/tag/v3.3.2)
 
 * Fixed issue where `version: dev` would fail when it produces no `git` changes

--- a/prepare-release.js
+++ b/prepare-release.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const getInputs = require('./utils/get-inputs');
 const getStdOut = require('./utils/get-stdout');
 const github = require('@actions/github');
+const hasDependencies = require('./utils/has-dependencies');
 const isLandoPlugin = require('./utils/is-lando-plugin');
 const jsonfile = require('jsonfile');
 const os = require('os');
@@ -194,17 +195,9 @@ const main = async () => {
     //
     // this happens AFTER sync because we ASSUME you do not have your node_modules checks into your repo
     // and if you do then this should be in your package.json already
-    if (inputs.bundleDependencies) {
-      // Check if there are dependencies to bundle
-      const pjson = jsonfile.readFileSync(inputs.pjson);
-      const hasDependencies = pjson.dependencies && Object.keys(pjson.dependencies).length > 0;
-
-      if (hasDependencies) {
-        await exec.exec(`${binDir}/bundle-dependencies`, ['update']);
-        await exec.exec(`${binDir}/bundle-dependencies`, ['list-bundled-dependencies']);
-      } else {
-        core.info('No dependencies found in package.json, skipping bundle-dependencies step');
-      }
+    if (inputs.bundleDependencies && hasDependencies(inputs.pjson)) {
+      await exec.exec(`${binDir}/bundle-dependencies`, ['update']);
+      await exec.exec(`${binDir}/bundle-dependencies`, ['list-bundled-dependencies']);
     }
 
     // lets also add the "dist" information, this key is required if you want the plugin to be updateable

--- a/prepare-release.js
+++ b/prepare-release.js
@@ -195,8 +195,16 @@ const main = async () => {
     // this happens AFTER sync because we ASSUME you do not have your node_modules checks into your repo
     // and if you do then this should be in your package.json already
     if (inputs.bundleDependencies) {
-      await exec.exec(`${binDir}/bundle-dependencies`, ['update']);
-      await exec.exec(`${binDir}/bundle-dependencies`, ['list-bundled-dependencies']);
+      // Check if there are dependencies to bundle
+      const pjson = jsonfile.readFileSync(inputs.pjson);
+      const hasDependencies = pjson.dependencies && Object.keys(pjson.dependencies).length > 0;
+
+      if (hasDependencies) {
+        await exec.exec(`${binDir}/bundle-dependencies`, ['update']);
+        await exec.exec(`${binDir}/bundle-dependencies`, ['list-bundled-dependencies']);
+      } else {
+        core.info('No dependencies found in package.json, skipping bundle-dependencies step');
+      }
     }
 
     // lets also add the "dist" information, this key is required if you want the plugin to be updateable

--- a/utils/has-dependencies.js
+++ b/utils/has-dependencies.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const core = require('@actions/core');
+const jsonfile = require('jsonfile');
+
+module.exports = pjson => {
+  const {dependencies} = jsonfile.readFileSync(pjson);
+
+  if (!dependencies || (dependencies && Object.keys(dependencies).length === 0)) {
+    core.info('No dependencies found in package.json, skipping bundle-dependencies step');
+  }
+
+  return typeof dependencies === 'object'
+     && dependencies !== null
+     && Object.keys(dependencies).length > 0;
+};


### PR DESCRIPTION
Ran into an issue after removing dependencies from the `mailpit` plugin. This action forces the bundler to run when it runs against a lando plugin. Now that mailpit has no dependencies, the bundler command fails. This PR adds a check to make sure there are actually dependencies before running the bundler bin.